### PR TITLE
[ProviderInfoDiscovery] Keep unknown scopes

### DIFF
--- a/src/oidcservice/oidc/provider_info_discovery.py
+++ b/src/oidcservice/oidc/provider_info_discovery.py
@@ -103,6 +103,7 @@ class ProviderInfoDiscovery(provider_info_discovery.ProviderInfoDiscovery):
         """
 
         if not pcr:
+            # OP capabilities here
             pcr = self.service_context.get('provider_info')
 
         regreq = oidc.RegistrationRequest
@@ -137,7 +138,10 @@ class ProviderInfoDiscovery(provider_info_discovery.ProviderInfoDiscovery):
                 except KeyError:
                     # Allow non standard claims
                     if isinstance(vals, list):
-                        _behaviour[_pref] = [v for v in vals if v in _pvals]
+                        # "if v in _pvals" would be adopted
+                        # a RP relying on oidcService will discard those
+                        # who not are available in op's provider discovery endpoint
+                        _behaviour[_pref] = [v for v in vals] # if v in _pvals]
                     elif vals in _pvals:
                         _behaviour[_pref] = vals
                 else:


### PR DESCRIPTION
This PR is also related to this: https://github.com/IdentityPython/oidcendpoint/issues/73

With this PR a RP can request unavailable/unknown scopes, independently by those reported by provider discovery informations.

OidcRP, with this PR, will hold the unknown/unavailable scopes in its authz request.
The behaviour of Authz Endpoint (OAuth2 or OIDC) would instead be based on the internal policy configured (oidcendpoint's deny_unknown_scopes).

This is an ambitious feature, which strives to bring jwtconnect py stack into a jungle of "pirated" RP / Clients not caring about the correct use of tokens (for the purposes for which they were released). This PR does not affect OP policies (as this does: https://github.com/IdentityPython/oidcendpoint/pull/85) but only the behaviour of RP, in front of the provider info response.